### PR TITLE
Changed sign convention of D to match paper

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2009-2022: Kipton Barros and David Dahlbom
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+end of terms and conditions
+
+Please see [THIRDPARTY.md](./THIRDPARTY.md) for license information for other software used in this project.

--- a/src/SchrodingerMidpoint.jl
+++ b/src/SchrodingerMidpoint.jl
@@ -149,8 +149,8 @@ function local_energy_and_gradient(sys::System{N}, s, i) where {N}
     end
 
     # LL easy axis, - D ∑ᵢ (nᵢᶻ)²
-    E += -sys.D*s[i][3]^2
-    ∇E += -Vec3(0, 0, 2sys.D*s[i][3])
+    E += sys.D*s[i][3]^2
+    ∇E += Vec3(0, 0, 2sys.D*s[i][3])
 
     # Zeeman coupling
     E += -sys.B ⋅ s[i]

--- a/src/fig1.jl
+++ b/src/fig1.jl
@@ -4,7 +4,7 @@ function fig1()
     # Classical LL-type anisotropy
     ################################################################################
     N = 3
-    D = 1.0
+    D = -1.0
     θ = (4/5)*(π/2)
     ω = 2cos(θ) # angular frequency proportional to B only
     Δt = 0.5

--- a/src/fig3.jl
+++ b/src/fig3.jl
@@ -35,10 +35,10 @@ function fig3()
 
 
     params = [
-        (; N = 2, D = 1., Δt = 0.02, step!fn = heun_step!, label="HeunP (non-symplectic)"),
-        (; N = 3, D = 1., Δt = 0.02, step!fn = midpoint_step!, label="Schrodinger midpoint, spin-1"),
-        (; N = 2, D = 1., Δt = 0.02, step!fn = midpoint_step!, label=raw"Schrodinger midpoint, spin-$\frac{1}{2}$"),
-        (; N = 0, D = 1., Δt = 0.02, step!fn = spherical_midpoint_step!, label="Spherical midpoint")
+        (; N = 2, D = -1., Δt = 0.02, step!fn = heun_step!, label="HeunP (non-symplectic)"),
+        (; N = 3, D = -1., Δt = 0.02, step!fn = midpoint_step!, label="Schrodinger midpoint, spin-1"),
+        (; N = 2, D = -1., Δt = 0.02, step!fn = midpoint_step!, label=raw"Schrodinger midpoint, spin-$\frac{1}{2}$"),
+        (; N = 0, D = -1., Δt = 0.02, step!fn = spherical_midpoint_step!, label="Spherical midpoint")
     ]
 
     data = map(params) do p

--- a/src/fig4.jl
+++ b/src/fig4.jl
@@ -5,12 +5,12 @@ function fig4()
     ################################################################################
 
     function collect_trajectory_gsd(; Δt)
-        D = 1.0
+        D = -1.0
         N = 3
         L = 100
 
         Sz = spin_operators(N)[3]
-        Λ = fill(-D*Sz^2, L)
+        Λ = fill(D*Sz^2, L)
 
         sys = System(; N, L, periodic=true, J=-1.0, Λ)
 


### PR DESCRIPTION
`fig[1-3].jl`: Changed sign of `D`.

`fig4.jl`: Change sign of `D` and then sign in definition of `Λ`.

`SchrodingerMidpoint.jl`: Changed sign of contribution to `E` and `∇E` for anisotropy (lines 152 and 153).